### PR TITLE
Make useful schema public

### DIFF
--- a/src/oauth/two.clj
+++ b/src/oauth/two.clj
@@ -22,10 +22,10 @@
    :request-method           RequestMethod
    :url                      s/Str})
 
-(def ^:private Scopes
+(def Scopes
   #{s/Str})
 
-(def ^:private ClientConfig
+(def ClientConfig
   {(s/optional-key :redirect-uri) s/Str
    (s/optional-key :scopes)       Scopes
    :access-uri                    s/Str
@@ -33,12 +33,12 @@
    :id                            s/Str
    :secret                        s/Str})
 
-(def ^:private AuthorizationParams
+(def AuthorizationParams
   {(s/optional-key :redirect-uri) s/Str
    (s/optional-key :scopes)       Scopes
    (s/optional-key :state)        s/Str})
 
-(def ^:private TokenRequestParams
+(def TokenRequestParams
   {(s/optional-key :redirect-uri) s/Str
    :code                          s/Str})
 


### PR DESCRIPTION
These schema are useful when you want to select keys before passing a map to one of the functions. For example, I use something like this to build clients:

``` clj
(require '[oauth.two :as two])

(defn- read-key
  [x]
  (get x :k k))

(s/defn provider->client :- oauth.two.Client
  [m]
  (-> m
      (set/rename-keys {})
      (select-keys (map read-key (keys two/ClientConfig)))
      two/make-client))
```
