### PR TITLE
Rename scopes to scope

### DIFF
--- a/src/oauth/two.clj
+++ b/src/oauth/two.clj
@@ -22,12 +22,12 @@
    :request-method           RequestMethod
    :url                      s/Str})
 
-(def Scopes
+(def Scope
   #{s/Str})
 
 (def ClientConfig
   {(s/optional-key :redirect-uri) s/Str
-   (s/optional-key :scopes)       Scopes
+   (s/optional-key :scope)        Scope
    :access-uri                    s/Str
    :authorize-uri                 s/Str
    :id                            s/Str
@@ -35,7 +35,7 @@
 
 (def AuthorizationParams
   {(s/optional-key :redirect-uri) s/Str
-   (s/optional-key :scopes)       Scopes
+   (s/optional-key :scope)        Scope
    (s/optional-key :state)        s/Str})
 
 (def TokenRequestParams
@@ -45,7 +45,7 @@
 ;; -----------------------------------------------------------------------------
 ;; Client
 
-(defrecord Client [access-uri authorize-uri id secret redirect-uri scopes])
+(defrecord Client [access-uri authorize-uri id secret redirect-uri scope])
 
 (s/defn make-client :- Client
   [config :- ClientConfig]
@@ -64,9 +64,9 @@
 ;; -----------------------------------------------------------------------------
 ;; Authorization URL
 
-(s/defn join-scopes :- (s/maybe s/Str)
-  [scopes :- (s/maybe Scopes)]
-  (when scopes (str/join " " scopes)))
+(s/defn join-scope :- (s/maybe s/Str)
+  [scope :- (s/maybe Scope)]
+  (some->> scope sort (str/join " ")))
 
 (s/defn authorization-url :- s/Str
   ([client :- Client]
@@ -78,7 +78,7 @@
          "client_id"     (:id client)
          "redirect_uri"  (or (:redirect-uri params) (:redirect-uri client))
          "response_type" "code"
-         "scopes"        (join-scopes (or (:scopes params) (:scopes client)))
+         "scope"        (join-scope (or (:scope params) (:scope client)))
          "state"         (:state params)))))
 
 ;; -----------------------------------------------------------------------------

--- a/test/oauth/two_test.clj
+++ b/test/oauth/two_test.clj
@@ -36,9 +36,9 @@
   (are [conf] (make-client (merge test-client-config conf))
     {:redirect-uri "https://example.com/callback"}
     {:redirect-uri "https://example.com/callback"
-     :scopes       #{"read" "write"}}
-    {:scopes #{"read"}}
-    {:scopes #{"read" "write"}}))
+     :scope        #{"read" "write"}}
+    {:scope #{"read"}}
+    {:scope #{"read" "write"}}))
 
 ;; -----------------------------------------------------------------------------
 ;; Authorization URL
@@ -68,19 +68,19 @@
              "redirect_uri"  "https://client.example.com/override/callback"
              "response_type" "code"}}
 
-   {:desc   "with scopes in the client"
-    :client {:scopes #{"read" "write"}}
+   {:desc   "with scope in the client"
+    :client {:scope #{"read" "write"}}
     :params {}
     :query  {"client_id"     "client-id"
              "response_type" "code"
-             "scopes"        "read write"}}
+             "scope"         "read write"}}
 
-   {:desc   "when overriding the client scopes with params"
-    :client {:scopes #{"read" "write"}}
-    :params {:scopes #{"override"}}
+   {:desc   "when overriding the client scope with params"
+    :client {:scope #{"read" "write"}}
+    :params {:scope #{"override"}}
     :query  {"client_id"     "client-id"
              "response_type" "code"
-             "scopes"        "override"}}
+             "scope"         "override"}}
 
    {:desc   "with some state"
     :client {}


### PR DESCRIPTION
Previously the scope was mistakenly passed to the OAuth provider via a
"scopes" query param. The correct parameter to use is "scope".

This has been fixed, and to avoid confusion I've replaced any use of
`:scopes` with `:scope`.
